### PR TITLE
Removed duplicate https from line 55 causing requests with 'https://h…

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ class sso_client {
         auth: this.ssoPaths
       });
       this.authURI = this.oauth2.authorizationCode.authorizeURL({
-        redirectURI: 'https://' + this.clientPaths.clientHost + '/callback'
+        redirectURI: this.clientPaths.clientHost + '/callback'
       });
       this.app.get('/callback', (req, res, next) => {
         this.callback(req, res);


### PR DESCRIPTION
Thanks for making this npm package! 

Once thing I noticed in index.js, on line 72 you created the client paths and appended 'https://' to it. 

However, on line 55, the code appends 'https://' again, creating authentication requests that have 'https://https://${clienthost}...'

I simply just removed the second 'https://' from line 55 since you already set this up. 

Feel free to reject this pull request and make the changes yourself if that's easier. 

Just wanted to help out. 

Thanks!